### PR TITLE
feat : 섭취 정보 삭제 구현

### DIFF
--- a/sosik-intake-service/src/main/java/com/example/sosikintakeservice/controller/IntakeController.java
+++ b/sosik-intake-service/src/main/java/com/example/sosikintakeservice/controller/IntakeController.java
@@ -30,4 +30,10 @@ public class IntakeController {
         return Result.success(responseGetIntakes);
     }
 
+    @DeleteMapping("/{intakeId}")
+    public Result<Void> deleteIntake(@PathVariable final Long intakeId) {
+        intakeService.deleteIntake(intakeId);
+        return Result.success();
+    }
+
 }

--- a/sosik-intake-service/src/main/java/com/example/sosikintakeservice/service/IntakeService.java
+++ b/sosik-intake-service/src/main/java/com/example/sosikintakeservice/service/IntakeService.java
@@ -9,5 +9,6 @@ import java.util.List;
 public interface IntakeService {
     String createIntake(RequestIntake intakeDTO);
     List<ResponseGetIntake> getIntakes(RequestGetIntake requestgetIntake);
+    String deleteIntake(Long intakeId);
 
 }

--- a/sosik-intake-service/src/main/java/com/example/sosikintakeservice/service/IntakeServiceImpl.java
+++ b/sosik-intake-service/src/main/java/com/example/sosikintakeservice/service/IntakeServiceImpl.java
@@ -58,6 +58,12 @@ public class IntakeServiceImpl implements IntakeService{
                 }).collect(Collectors.toList());
     }
 
-
+    public String deleteIntake(Long intakeId) {
+        if(intakeRepository.findById(intakeId)==null){
+            throw new ApplicationException(ErrorCode.INTAKE_NOT_FOUND);
+        }
+        intakeRepository.deleteById(intakeId);
+        return "ok";
+    }
 
 }

--- a/sosik-intake-service/src/test/java/com/example/sosikintakeservice/service/intakeServiceTest.java
+++ b/sosik-intake-service/src/test/java/com/example/sosikintakeservice/service/intakeServiceTest.java
@@ -3,6 +3,7 @@ package com.example.sosikintakeservice.service;
 import com.example.sosikintakeservice.dto.request.RequestGetFoodInfo;
 import com.example.sosikintakeservice.dto.request.RequestIntake;
 import com.example.sosikintakeservice.dto.response.ResponseGetIntake;
+import com.example.sosikintakeservice.dto.response.Result;
 import com.example.sosikintakeservice.exception.ApplicationException;
 import com.example.sosikintakeservice.model.entity.Category;
 import com.example.sosikintakeservice.repository.IntakeRepository;
@@ -12,6 +13,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.bind.annotation.DeleteMapping;
+
 import java.math.BigDecimal;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,6 +75,19 @@ public class intakeServiceTest {
         assertThat(actualResponse).isEqualTo(expectedResponse);
     }
 
+    @DisplayName("섭취 음식 삭제시 정상적으로 작동된다.")
+    @Test
+    void givenTestMemberWhenDeleteMemberThenSuccess(){
+        String ok = intakeService.deleteIntake(1L);
+        assertThat(ok).isEqualTo("ok");
+    }
+
+    @DisplayName("섭취 음식 삭제시 존재하지 않는다.")
+    @Test
+    void givenTestMemberWhenDeleteMemberThrowINTAKE_NOT_FOUND(){
+        given(intakeRepository.findById(any())).willReturn(null);
+        assertThatThrownBy(()-> intakeService.deleteIntake(1L)).isInstanceOf(ApplicationException.class);
+    }
 
 
     private static RequestIntake testIntakeDTO() {


### PR DESCRIPTION
## 🏷 작업 분류

- [X]  기능 추가
- [ ]  리팩토링
- [ ]  버그 수정
- [ ]  환경 수정 및 기타

## 💡 작업 개요
섭취 정보 삭제 구현했습니다.
테스트 코드는 정상적으로 삭제됐을 때와 섭취 음식 삭제시 섭취가 존재하지 않은 경우를 추가했습니다.

## ***📜** 리뷰 요청사항*
